### PR TITLE
chore: switch default from v5 to v6

### DIFF
--- a/src/ui/contexts/VersionContext.tsx
+++ b/src/ui/contexts/VersionContext.tsx
@@ -15,7 +15,7 @@ export interface VersionSupported {
 const VersionContext = createContext<VersionSupported | undefined>(undefined);
 
 export const VersionContextProvider = ({ children }: React.PropsWithChildren) => {
-  const [version, setVersion] = useLocalStorage<InkVersion>(LOCAL_STORAGE_KEY.VERSION, 'v5');
+  const [version, setVersion] = useLocalStorage<InkVersion>(LOCAL_STORAGE_KEY.VERSION, 'v6');
 
   useEffect(() => setVersion(version), [version]);
 
@@ -33,4 +33,4 @@ export const useVersion = () => {
 };
 
 export const getVersion = () =>
-  (localStorage.getItem(LOCAL_STORAGE_KEY.VERSION) as InkVersion | null) || 'v5';
+  (localStorage.getItem(LOCAL_STORAGE_KEY.VERSION) as InkVersion | null) || 'v6';

--- a/src/ui/layout/sidebar/VersionSelect.tsx
+++ b/src/ui/layout/sidebar/VersionSelect.tsx
@@ -5,12 +5,12 @@ export function VersionSelect() {
   const { version, setVersion } = useVersion();
   const dropdownOptions = [
     {
-      label: 'ink! v5 (default)',
-      value: 'v5',
+      label: 'ink! v6 (default)',
+      value: 'v6',
     },
     {
-      label: 'ink! v6',
-      value: 'v6',
+      label: 'ink! v5',
+      value: 'v5',
     },
   ];
   return (


### PR DESCRIPTION
As we did in `cargo-contracts` and the `ink-docs` https://github.com/use-ink/ink-docs/pull/432  it makes sense to have ink! v6 as the default in Contracts UI as well.